### PR TITLE
Index converters & doc updates

### DIFF
--- a/python/doc/Makefile
+++ b/python/doc/Makefile
@@ -1,0 +1,216 @@
+# Makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+PAPER         =
+BUILDDIR      = _build
+
+# User-friendly check for sphinx-build
+ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+endif
+
+# Internal variables.
+PAPEROPT_a4     = -D latex_paper_size=a4
+PAPEROPT_letter = -D latex_paper_size=letter
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+# the i18n builder cannot share the environment and doctrees with the others
+I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+
+.PHONY: help
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  html       to make standalone HTML files"
+	@echo "  dirhtml    to make HTML files named index.html in directories"
+	@echo "  singlehtml to make a single large HTML file"
+	@echo "  pickle     to make pickle files"
+	@echo "  json       to make JSON files"
+	@echo "  htmlhelp   to make HTML files and a HTML help project"
+	@echo "  qthelp     to make HTML files and a qthelp project"
+	@echo "  applehelp  to make an Apple Help Book"
+	@echo "  devhelp    to make HTML files and a Devhelp project"
+	@echo "  epub       to make an epub"
+	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
+	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
+	@echo "  text       to make text files"
+	@echo "  man        to make manual pages"
+	@echo "  texinfo    to make Texinfo files"
+	@echo "  info       to make Texinfo files and run them through makeinfo"
+	@echo "  gettext    to make PO message catalogs"
+	@echo "  changes    to make an overview of all changed/added/deprecated items"
+	@echo "  xml        to make Docutils-native XML files"
+	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
+	@echo "  linkcheck  to check all external links for integrity"
+	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  coverage   to run coverage check of the documentation (if enabled)"
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILDDIR)/*
+
+.PHONY: html
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+.PHONY: dirhtml
+dirhtml:
+	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+.PHONY: singlehtml
+singlehtml:
+	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
+	@echo
+	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
+
+.PHONY: pickle
+pickle:
+	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
+	@echo
+	@echo "Build finished; now you can process the pickle files."
+
+.PHONY: json
+json:
+	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
+	@echo
+	@echo "Build finished; now you can process the JSON files."
+
+.PHONY: htmlhelp
+htmlhelp:
+	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
+	@echo
+	@echo "Build finished; now you can run HTML Help Workshop with the" \
+	      ".hhp project file in $(BUILDDIR)/htmlhelp."
+
+.PHONY: qthelp
+qthelp:
+	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
+	@echo
+	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
+	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/casm_mapping.qhcp"
+	@echo "To view the help file:"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/casm_mapping.qhc"
+
+.PHONY: applehelp
+applehelp:
+	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
+	@echo
+	@echo "Build finished. The help book is in $(BUILDDIR)/applehelp."
+	@echo "N.B. You won't be able to view it unless you put it in" \
+	      "~/Library/Documentation/Help or install it in your application" \
+	      "bundle."
+
+.PHONY: devhelp
+devhelp:
+	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
+	@echo
+	@echo "Build finished."
+	@echo "To view the help file:"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/casm_mapping"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/casm_mapping"
+	@echo "# devhelp"
+
+.PHONY: epub
+epub:
+	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	@echo
+	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
+
+.PHONY: latex
+latex:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo
+	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
+	@echo "Run \`make' in that directory to run these through (pdf)latex" \
+	      "(use \`make latexpdf' here to do that automatically)."
+
+.PHONY: latexpdf
+latexpdf:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through pdflatex..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+.PHONY: latexpdfja
+latexpdfja:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through platex and dvipdfmx..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+.PHONY: text
+text:
+	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
+	@echo
+	@echo "Build finished. The text files are in $(BUILDDIR)/text."
+
+.PHONY: man
+man:
+	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	@echo
+	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
+
+.PHONY: texinfo
+texinfo:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo
+	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
+	@echo "Run \`make' in that directory to run these through makeinfo" \
+	      "(use \`make info' here to do that automatically)."
+
+.PHONY: info
+info:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo "Running Texinfo files through makeinfo..."
+	make -C $(BUILDDIR)/texinfo info
+	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
+
+.PHONY: gettext
+gettext:
+	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
+	@echo
+	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
+
+.PHONY: changes
+changes:
+	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
+	@echo
+	@echo "The overview file is in $(BUILDDIR)/changes."
+
+.PHONY: linkcheck
+linkcheck:
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	@echo
+	@echo "Link check complete; look for any errors in the above output " \
+	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+.PHONY: doctest
+doctest:
+	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
+	@echo "Testing of doctests in the sources finished, look at the " \
+	      "results in $(BUILDDIR)/doctest/output.txt."
+
+.PHONY: coverage
+coverage:
+	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
+	@echo "Testing of coverage in the sources finished, look at the " \
+	      "results in $(BUILDDIR)/coverage/python.txt."
+
+.PHONY: xml
+xml:
+	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
+	@echo
+	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
+
+.PHONY: pseudoxml
+pseudoxml:
+	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
+	@echo
+	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."

--- a/python/doc/_templates/base.rst
+++ b/python/doc/_templates/base.rst
@@ -1,0 +1,5 @@
+{{ name | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/python/doc/_templates/custom-attr-template.rst
+++ b/python/doc/_templates/custom-attr-template.rst
@@ -1,0 +1,5 @@
+{{ name | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/python/doc/_templates/custom-class-template.rst
+++ b/python/doc/_templates/custom-class-template.rst
@@ -3,32 +3,34 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
+  :show-inheritance:
 
-   {% block methods %}
-   {% if methods %}
-   .. rubric:: {{ _('Methods') }}
+  {% block methods %}
+  {% if methods %}
+  .. rubric:: {{ _('Methods') }}
 
-   .. autosummary::
-      :nosignatures:
-      :toctree:
-      :template: custom-function-template.rst
-   {% for item in methods %}
-      {%- if not item.startswith('_') %}
+  .. autosummary::
+    :nosignatures:
+    :toctree:
+    :template: custom-function-template.rst
+  {% for item in methods %}
+    {%- if not item.startswith('_') %}
+    ~{{ name }}.{{ item }}
+    {%- endif -%}
+  {%- endfor %}
+  {% endif %}
+  {% endblock %}
+
+  {% block attributes %}
+  {% if attributes %}
+  .. rubric:: {{ _('Attributes') }}
+
+  .. autosummary::
+    :nosignatures:
+    :toctree:
+    :template: custom-attr-template.rst
+    {% for item in attributes %}
       ~{{ name }}.{{ item }}
-      {%- endif -%}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block attributes %}
-   {% if attributes %}
-   .. rubric:: {{ _('Attributes') }}
-
-   .. autosummary::
-      :nosignatures:
-      :toctree:
-   {% for item in attributes %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+    {%- endfor %}
+    {% endif %}
+    {% endblock %}

--- a/python/doc/_templates/custom-class-template.rst
+++ b/python/doc/_templates/custom-class-template.rst
@@ -1,10 +1,8 @@
-{{ fullname | escape | underline}}
+{{ name | escape | underline}}
 
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-   :members:
-   :special-members: __call__, __add__, __sub__, __mul__, __truediv__, __iadd__, __isub__, __lt__, __le__, __gt__, __ge__, __eq__, __ne__
 
    {% block methods %}
    {% if methods %}
@@ -12,6 +10,8 @@
 
    .. autosummary::
       :nosignatures:
+      :toctree:
+      :template: custom-function-template.rst
    {% for item in methods %}
       {%- if not item.startswith('_') %}
       ~{{ name }}.{{ item }}
@@ -25,6 +25,8 @@
    .. rubric:: {{ _('Attributes') }}
 
    .. autosummary::
+      :nosignatures:
+      :toctree:
    {% for item in attributes %}
       ~{{ name }}.{{ item }}
    {%- endfor %}

--- a/python/doc/_templates/custom-function-template.rst
+++ b/python/doc/_templates/custom-function-template.rst
@@ -1,0 +1,5 @@
+{{ name | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/python/doc/_templates/custom-module-template.rst
+++ b/python/doc/_templates/custom-module-template.rst
@@ -2,70 +2,70 @@
 
 .. automodule:: {{ fullname }}
 
-   {% block attributes %}
-   {% if attributes %}
-   .. rubric:: Module Attributes
+  {% block attributes %}
+  {% if attributes %}
+  .. rubric:: Module Attributes
 
-   .. autosummary::
-      :nosignatures:
-      :toctree:
-   {% for item in attributes %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+  .. autosummary::
+    :nosignatures:
+    :toctree:
+  {% for item in attributes %}
+    {{ item }}
+  {%- endfor %}
+  {% endif %}
+  {% endblock %}
 
-   {% block functions %}
-   {% if functions %}
-   .. rubric:: {{ _('Functions') }}
+  {% block functions %}
+  {% if functions %}
+  .. rubric:: {{ _('Functions') }}
 
-   .. autosummary::
-      :nosignatures:
-      :toctree:
-      :template: custom-function-template.rst
-   {% for item in functions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+  .. autosummary::
+    :nosignatures:
+    :toctree:
+    :template: custom-function-template.rst
+  {% for item in functions %}
+    {{ item }}
+  {%- endfor %}
+  {% endif %}
+  {% endblock %}
 
-   {% block classes %}
-   {% if classes %}
-   .. rubric:: {{ _('Classes') }}
+  {% block classes %}
+  {% if classes %}
+  .. rubric:: {{ _('Classes') }}
 
-   .. autosummary::
-      :nosignatures:
-      :toctree:
-      :template: custom-class-template.rst
-   {% for item in classes %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+  .. autosummary::
+    :nosignatures:
+    :toctree:
+    :template: custom-class-template.rst
+  {% for item in classes %}
+    {{ item }}
+  {%- endfor %}
+  {% endif %}
+  {% endblock %}
 
-   {% block exceptions %}
-   {% if exceptions %}
-   .. rubric:: {{ _('Exceptions') }}
+  {% block exceptions %}
+  {% if exceptions %}
+  .. rubric:: {{ _('Exceptions') }}
 
-   .. autosummary::
-      :nosignatures:
-      :toctree:
-   {% for item in exceptions %}
-      {{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+  .. autosummary::
+    :nosignatures:
+    :toctree:
+  {% for item in exceptions %}
+    {{ item }}
+  {%- endfor %}
+  {% endif %}
+  {% endblock %}
 
 {% block modules %}
 {% if modules %}
 .. rubric:: Modules
 
 .. autosummary::
-   :toctree:
-   :template: custom-module-template.rst
-   :recursive:
+  :toctree:
+  :template: custom-module-template.rst
+  :recursive:
 {% for item in modules %}
-   {{ item }}
+  {{ item }}
 {%- endfor %}
 {% endif %}
 {% endblock %}

--- a/python/doc/_templates/custom-module-template.rst
+++ b/python/doc/_templates/custom-module-template.rst
@@ -7,6 +7,7 @@
    .. rubric:: Module Attributes
 
    .. autosummary::
+      :nosignatures:
       :toctree:
    {% for item in attributes %}
       {{ item }}
@@ -19,7 +20,9 @@
    .. rubric:: {{ _('Functions') }}
 
    .. autosummary::
+      :nosignatures:
       :toctree:
+      :template: custom-function-template.rst
    {% for item in functions %}
       {{ item }}
    {%- endfor %}
@@ -31,6 +34,7 @@
    .. rubric:: {{ _('Classes') }}
 
    .. autosummary::
+      :nosignatures:
       :toctree:
       :template: custom-class-template.rst
    {% for item in classes %}
@@ -44,6 +48,7 @@
    .. rubric:: {{ _('Exceptions') }}
 
    .. autosummary::
+      :nosignatures:
       :toctree:
    {% for item in exceptions %}
       {{ item }}

--- a/python/doc/conf.py
+++ b/python/doc/conf.py
@@ -32,8 +32,8 @@ autoclass_content = "both"
 autosummary_generate = True
 autosummary_imported_members = True
 numpydoc_show_class_members = False
-#autodoc_typehints = 'both'
-autodoc_typehints_format = 'short'
+# autodoc_typehints = 'both'
+autodoc_typehints_format = "short"
 python_use_unqualified_type_names = True
 autodoc_inherit_docstrings = False
 add_module_names = True
@@ -44,16 +44,16 @@ intersphinx_mapping = {}
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.coverage',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
-    'sphinx.ext.napoleon',
-    'sphinxarg.ext',
-    'sphinxcontrib.bibtex',
-    'sphinx.ext.intersphinx',
-    'numpydoc',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.coverage",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.napoleon",
+    "sphinxarg.ext",
+    "sphinxcontrib.bibtex",
+    "sphinx.ext.intersphinx",
+    "numpydoc",
 ]
 
 bibtex_bibfiles = ["refs.bib"]

--- a/python/src/xtal.cpp
+++ b/python/src/xtal.cpp
@@ -829,10 +829,10 @@ PYBIND11_MODULE(_xtal, m) {
   using namespace CASMpy;
 
   m.doc() = R"pbdoc(
-        casm.xtal
-        ---------
+        libcasm.xtal
+        ------------
 
-        The casm.xtal module is a Python interface to the crystallography
+        The libcasm.xtal module is a Python interface to the crystallography
         classes and methods in the CASM::xtal namespace of the CASM C++ libraries.
         This includes:
 
@@ -879,6 +879,45 @@ PYBIND11_MODULE(_xtal, m) {
 
   py::class_<xtal::Lattice>(m, "Lattice", R"pbdoc(
       A 3-dimensional lattice
+
+      .. rubric:: Special Methods
+
+      Sort :class:`~libcasm.xtal.Lattice` by how canonical the lattice vectors are via ``<``, ``<=``, ``>``, ``>=`` (see also `Lattice Canonical Form`_.), and check if lattice are approximately equal via ``==``, ``!=``:
+
+      .. code-block:: Python
+
+          import libcasm.xtal as xtal
+
+          L1 = xtal.Lattice( # less canonical, lesser
+              np.array(
+                  [
+                      [0.0, 0.0, 2.0],
+                      [1.0, 0.0, 0.0],
+                      [0.0, 1.0, 0.0],
+                  ]
+              ).transpose()
+          )
+          L2 = xtal.Lattice( # more canonical, greater
+              np.array(
+                  [
+                      [1.0, 0.0, 0.0],
+                      [0.0, 1.0, 0.0],
+                      [0.0, 0.0, 2.0],
+                  ]
+              ).transpose()
+          )
+          assert L1 < L2
+          assert L1 <= L2
+          assert L2 > L1
+          assert L2 >= L1
+          assert (L1 == L2) == False
+          assert L1 != L2
+          assert L1 == L1
+          assert (L1 != L1) == False
+          assert xtal.is_equivalent_to(L1, L2) == True
+
+
+      .. _`Lattice Canonical Form`: https://prisms-center.github.io/CASMcode_docs/formats/lattice_canonical_form/
       )pbdoc")
       .def(py::init<Eigen::Matrix3d const &, double, bool>(),
            "Construct a Lattice", py::arg("column_vector_matrix"),
@@ -931,12 +970,12 @@ PYBIND11_MODULE(_xtal, m) {
 
     Parameters
     ----------
-    init_lattice : casm.xtal.Lattice
+    init_lattice : ~libcasm.xtal.Lattice
         The initial lattice.
 
     Returns
     -------
-    lattice : casm.xtal.Lattice
+    lattice : ~libcasm.xtal.Lattice
         The canonical equivalent lattice, using the lattice point group.
     )pbdoc");
 
@@ -955,7 +994,7 @@ PYBIND11_MODULE(_xtal, m) {
 
     Parameters
     ----------
-    lattice : casm.xtal.Lattice
+    lattice : ~libcasm.xtal.Lattice
         The lattice.
     coordinate_frac : array_like, shape (3, n)
         Coordinates, as columns of a matrix, in fractional coordinates
@@ -979,7 +1018,7 @@ PYBIND11_MODULE(_xtal, m) {
 
     Parameters
     ----------
-    lattice : casm.xtal.Lattice
+    lattice : ~libcasm.xtal.Lattice
         The lattice.
     coordinate_cart : array_like, shape (3, n)
         Coordinates, as columns of a matrix, in Cartesian coordinates.
@@ -997,7 +1036,7 @@ PYBIND11_MODULE(_xtal, m) {
 
     Parameters
     ----------
-    lattice : casm.xtal.Lattice
+    lattice : ~libcasm.xtal.Lattice
         The lattice.
     init_coordinate_frac : array_like, shape (3, n)
         Coordinates, as columns of a matrix, in fractional coordinates
@@ -1029,7 +1068,7 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      lattice : casm.xtal.Lattice
+      lattice : ~libcasm.xtal.Lattice
           The lattice, defining the periodic boundaries.
       r1 : array_like, shape (3, 1)
           Position, r1, in Cartesian coordinates.
@@ -1055,12 +1094,12 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      lattice : casm.xtal.Lattice
+      lattice : ~libcasm.xtal.Lattice
           The lattice.
 
       Returns
       -------
-      point_group : List[casm.xtal.SymOp]
+      point_group : List[:class:`~libcasm.xtal.SymOp`]
           The set of rigid transformations that keep the origin fixed
           (i.e. have zero translation vector) and map the lattice (i.e.
           all points that are integer multiples of the lattice vectors)
@@ -1083,9 +1122,9 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      lattice1 : casm.xtal.Lattice
+      lattice1 : ~libcasm.xtal.Lattice
           The first lattice.
-      lattice2 : casm.xtal.Lattice
+      lattice2 : ~libcasm.xtal.Lattice
           The second lattice.
 
       Returns
@@ -1110,9 +1149,9 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      lattice1 : casm.xtal.Lattice
+      lattice1 : ~libcasm.xtal.Lattice
           The first lattice.
-      lattice2 : casm.xtal.Lattice
+      lattice2 : ~libcasm.xtal.Lattice
           The second lattice.
 
       Returns
@@ -1142,11 +1181,11 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      lattice1 : casm.xtal.Lattice
+      lattice1 : ~libcasm.xtal.Lattice
           The first lattice.
-      lattice2 : casm.xtal.Lattice
+      lattice2 : ~libcasm.xtal.Lattice
           The second lattice.
-      point_group : List[casm.xtal.SymOp]
+      point_group : List[:class:`~libcasm.xtal.SymOp`]
           The point group symmetry that generates equivalent lattices. Depending
           on the use case, this is often the prim crystal point group,
           :func:`~casm.xtal.make_crystal_point_group()`, or the lattice
@@ -1172,9 +1211,9 @@ PYBIND11_MODULE(_xtal, m) {
 
      Parameters
      ----------
-     superlattice : casm.xtal.Lattice
+     superlattice : ~libcasm.xtal.Lattice
          The superlattice.
-     unit_lattice : casm.xtal.Lattice
+     unit_lattice : ~libcasm.xtal.Lattice
          The unit lattice.
 
      Returns
@@ -1216,9 +1255,9 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      unit_lattice : casm.xtal.Lattice
+      unit_lattice : ~libcasm.xtal.Lattice
           The unit lattice.
-      point_group : List[casm.xtal.SymOp]
+      point_group : List[:class:`~libcasm.xtal.SymOp`]
           The point group symmetry that determines if superlattices are equivalent. Depending on the use case, this is often the prim crystal point group, :func:`~casm.xtal.make_crystal_point_group()`, or the lattice point group, :func:`~casm.xtal.make_point_group()`.
       max_volume : int
           The maximum volume superlattice to enumerate, as a multiple of the volume of unit_lattice.
@@ -1231,7 +1270,7 @@ PYBIND11_MODULE(_xtal, m) {
 
       Returns
       -------
-      superlattices : List[casm.xtal.Lattice]
+      superlattices : List[:class:`~libcasm.xtal.Lattice`]
           A list of superlattices of the unit lattice which are distinct under application of
           point_group. The resulting lattices will be in canonical form with respect to the
           point_group.
@@ -1244,7 +1283,7 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      lattices : List[casm.xtal.Lattice]
+      lattices : List[:class:`~libcasm.xtal.Lattice`]
           List of lattices.
       mode : str, default="commensurate"
           One of:
@@ -1259,7 +1298,7 @@ PYBIND11_MODULE(_xtal, m) {
 
       Returns
       -------
-      superduperlattice : casm.xtal.Lattice
+      superduperlattice : ~libcasm.xtal.Lattice
           The superduperlattice
       )pbdoc");
 
@@ -1323,7 +1362,7 @@ PYBIND11_MODULE(_xtal, m) {
           A \"chemical name\", which must be identical for occupants to
           be found symmetrically equivalent. The names are case
           sensitive, and "Va" is reserved for vacancies.
-      atoms : List[casm.xtal.AtomComponent], optional
+      atoms : List[:class:`~libcasm.xtal.AtomComponent`], optional
           The atomic components of a molecular occupant. Atoms and
           vacancies are represented with a single AtomComponent with the
           same name for the Occupant and the AtomComponent. If atoms is
@@ -1363,13 +1402,13 @@ PYBIND11_MODULE(_xtal, m) {
   m.def("make_vacancy", &xtal::Molecule::make_vacancy, R"pbdoc(
       Construct a Occupant object representing a vacancy
 
-      This function is equivalent to ``casm.xtal.Occupant("Va")``.
+      This function is equivalent to :func:`~libcasm.xtal.Occupant("Va")`.
       )pbdoc");
 
   m.def("make_atom", &xtal::Molecule::make_atom, py::arg("name"), R"pbdoc(
       Construct a Occupant object representing a single isotropic atom
 
-      This function is equivalent to ``casm.xtal.Occupant(name)``.
+      This function is equivalent to :func:`~libcasm.xtal.Occupant(name)`.
 
       Parameters
       ----------
@@ -1495,7 +1534,7 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      lattice : Lattice
+      lattice : ~libcasm.xtal.Lattice
           The primitive cell Lattice.
       coordinate_frac : array_like, shape (3, n)
           Basis site positions, as columns of a matrix, in fractional
@@ -1507,13 +1546,13 @@ PYBIND11_MODULE(_xtal, m) {
           an isotropic atom (i.e. "Mg") or vacancy ("Va"), or (ii) a key
           in the occupants dictionary (i.e. "H2O", or "H2_xx"). The names
           are case sensitive, and "Va" is reserved for vacancies.
-      local_dof : List[List[DoFSetBasis]], default=[[]]
+      local_dof : List[List[:class:`~libcasm.xtal.DoFSetBasis`]], default=[[]]
           Continuous DoF allowed on each basis site. No effect if empty.
           If not empty, the value local_dof[b] is a list of :class:`DoFSetBasis`
           objects describing the DoF allowed on the `b`-th basis site.
-      global_dof : List[DoFSetBasis], default=[]
+      global_dof : List[:class:`~libcasm.xtal.DoFSetBasis`], default=[]
           Global continuous DoF allowed for the entire crystal.
-      occupants : Dict[str, Occupant], default=[]
+      occupants : Dict[str,:class:`~libcasm.xtal.Occupant`], default=[]
           :class:`Occupant` allowed in the crystal. The keys are labels
           ('orientation names') used in the occ_dof parameter. This may
           include isotropic atoms, vacancies, atoms with fixed anisotropic
@@ -1607,12 +1646,12 @@ PYBIND11_MODULE(_xtal, m) {
                 set to only allow the POSCAR atom types. This may be
                 provided, to explicitly set the occupation DoF.
 
-            xtal_tol: float = xtal.TOL
+            xtal_tol: float = ~libcasm.xtal.TOL
                 Tolerance used for lattice.
 
             Returns
             -------
-            prim : casm.xtal.Prim
+            prim : ~libcasm.xtal.Prim
                 A Prim
 
             )pbdoc",
@@ -1633,12 +1672,12 @@ PYBIND11_MODULE(_xtal, m) {
                 set to only allow the POSCAR atom types. This may be
                 provided, to explicitly set the occupation DoF.
 
-            xtal_tol: float = xtal.TOL
+            xtal_tol: float = ~libcasm.xtal.TOL
                 Tolerance used for lattice.
 
             Returns
             -------
-            prim : casm.xtal.Prim
+            prim : ~libcasm.xtal.Prim
                 A Prim
 
             )pbdoc",
@@ -1676,15 +1715,15 @@ PYBIND11_MODULE(_xtal, m) {
 
             Parameters
             ----------
-            first : casm.xtal.Prim
+            first : ~libcasm.xtal.Prim
                 First Prim.
 
-            second : casm.xtal.SharedPrim
+            second : ~libcasm.xtal.Prim
                 Second Prim.
 
             Returns
             -------
-            is_same : casm.xtal.Prim
+            is_same : ~libcasm.xtal.Prim
                 Returns true if Prim are sharing the same data
 
             )pbdoc");
@@ -1696,12 +1735,12 @@ PYBIND11_MODULE(_xtal, m) {
 
             Parameters
             ----------
-            init_prim : casm.xtal.Prim
+            init_prim : ~libcasm.xtal.Prim
                 Initial prim.
 
             Returns
             -------
-            prim : casm.xtal.Prim
+            prim : ~libcasm.xtal.Prim
                 A copy of the initial prim, sharing the same data.
 
             )pbdoc");
@@ -1713,12 +1752,12 @@ PYBIND11_MODULE(_xtal, m) {
 
             Parameters
             ----------
-            init_prim : casm.xtal.Prim
+            init_prim : ~libcasm.xtal.Prim
                 Initial prim.
 
             Returns
             -------
-            prim : casm.xtal.Prim
+            prim : ~libcasm.xtal.Prim
                 A copy of the initial prim, not sharing the same data.
 
             )pbdoc");
@@ -1728,12 +1767,12 @@ PYBIND11_MODULE(_xtal, m) {
 
             Parameters
             ----------
-            init_prim : casm.xtal.Prim
+            init_prim : ~libcasm.xtal.Prim
                 The initial prim.
 
             Returns
             -------
-            prim : casm.xtal.Prim
+            prim : ~libcasm.xtal.Prim
                 The prim with all basis site coordinates within the unit cell.
 
             )pbdoc");
@@ -1753,12 +1792,12 @@ PYBIND11_MODULE(_xtal, m) {
 
             Parameters
             ----------
-            init_prim : casm.xtal.Prim
+            init_prim : ~libcasm.xtal.Prim
                 The initial prim.
 
             Returns
             -------
-            prim : Lattice
+            prim : ~libcasm.xtal.Lattice
                 The primitive equivalent prim.
             )pbdoc");
 
@@ -1776,12 +1815,12 @@ PYBIND11_MODULE(_xtal, m) {
 
           Parameters
           ----------
-          init_prim : casm.xtal.Prim
+          init_prim : ~libcasm.xtal.Prim
               The initial prim.
 
           Returns
           -------
-          prim : Lattice
+          prim : ~libcasm.xtal.Lattice
               The prim with canonical lattice.
 
         )pbdoc");
@@ -1795,7 +1834,7 @@ PYBIND11_MODULE(_xtal, m) {
 
           Parameters
           ----------
-          prim : casm.xtal.Prim
+          prim : ~libcasm.xtal.Prim
               The prim.
 
           Returns
@@ -1813,12 +1852,12 @@ PYBIND11_MODULE(_xtal, m) {
 
           Parameters
           ----------
-          prim : casm.xtal.Prim
+          prim : ~libcasm.xtal.Prim
               The prim.
 
           Returns
           -------
-          factor_group : List[casm.xtal.SymOp]
+          factor_group : List[:class:`~libcasm.xtal.SymOp`]
               The the set of symmery operations, with translation lying within the primitive unit
               cell, that leave the lattice vectors, basis site coordinates, and all DoF invariant.
 
@@ -1834,12 +1873,12 @@ PYBIND11_MODULE(_xtal, m) {
 
           Parameters
           ----------
-          prim : casm.xtal.Prim
+          prim : ~libcasm.xtal.Prim
               The prim.
 
           Returns
           -------
-          crystal_point_group : List[casm.xtal.SymOp]
+          crystal_point_group : List[:class:`~libcasm.xtal.SymOp`]
               The crystal point group is the group constructed from the prim factor group operations
               with translation vector set to zero.
 
@@ -1870,6 +1909,17 @@ PYBIND11_MODULE(_xtal, m) {
 
       where s_before and s_after are the spins before and after
       transformation, respectively.
+
+      .. rubric:: Special Methods
+
+      The multiplication operator ``X = lhs * rhs`` can be used to apply SymOp to various objects:
+
+      - ``X=SymOp``, ``lhs=SymOp``, ``rhs=SymOp``: Construct the :class:`~libcasm.xtal.SymOp`, `X`, equivalent to applying first `rhs`, then `lhs`.
+      - ``X=np.ndarray``, ``lhs=SymOp``, ``rhs=np.ndarray``: Transform multiple Cartesian coordinates, represented as columns of a `np.ndarray`.
+      - ``X=Dict[str,np.ndarray]``, ``lhs=SymOp``, ``rhs=Dict[str,np.ndarray]``: Transform CASM-supported properties (local or global). Keys must be the name of a CASM-supported property type. Values are arrays with the number of rows matching the standard dimension of the property type. For local properties, columns correspond to the value associated with each site. For global properties, there is one column. See the CASM `Degrees of Freedom (DoF) and Properties`_ documentation for the full list of supported properties and their definitions.
+      - ``X=Structure``, ``lhs=SymOp``, ``rhs=Structure``: Transform a :class:`~libcasm.xtal.Structure`.
+
+      .. _`Degrees of Freedom (DoF) and Properties`: https://prisms-center.github.io/CASMcode_docs/formats/dof_and_properties/
 
       )pbdoc")
       .def(py::init(&make_symop), py::arg("matrix"), py::arg("translation"),
@@ -1978,9 +2028,9 @@ PYBIND11_MODULE(_xtal, m) {
 
           Parameters
           ----------
-          op : casm.xtal.SymOp
+          op : ~libcasm.xtal.SymOp
               The symmetry operation.
-          lattice : casm.xtal.Lattice
+          lattice : ~libcasm.xtal.Lattice
               The lattice
           )pbdoc")
       .def("op_type", &get_syminfo_type, R"pbdoc(
@@ -2107,11 +2157,9 @@ PYBIND11_MODULE(_xtal, m) {
               std::map<std::string, Eigen::MatrixXd>{},
           R"pbdoc(
 
-    .. _prim-init:
-
     Parameters
     ----------
-    lattice : Lattice
+    lattice : ~libcasm.xtal.Lattice
         The Lattice.
     atom_coordinate_frac : array_like, shape (3, n)
         Atom positions, as columns of a matrix, in fractional
@@ -2198,12 +2246,12 @@ PYBIND11_MODULE(_xtal, m) {
             poscar_path : str
                 Path to the POSCAR file
 
-            xtal_tol: float = xtal.TOL
+            xtal_tol: float = ~libcasm.xtal.TOL
                 Tolerance used for lattice.
 
             Returns
             -------
-            struture : casm.xtal.Structure
+            struture : ~libcasm.xtal.Structure
                 A Structure
 
             )pbdoc",
@@ -2217,12 +2265,12 @@ PYBIND11_MODULE(_xtal, m) {
             poscar_str : str
                 The POSCAR as a string
 
-            xtal_tol: float = xtal.TOL
+            xtal_tol: float = ~libcasm.xtal.TOL
                 Tolerance used for lattice.
 
             Returns
             -------
-            struture : casm.xtal.Structure
+            struture : ~libcasm.xtal.Structure
                 A Structure
 
             )pbdoc",
@@ -2274,7 +2322,7 @@ PYBIND11_MODULE(_xtal, m) {
 
             Returns
             -------
-            struture : casm.xtal.Structure
+            struture : ~libcasm.xtal.Structure
                 A Structure
 
             )pbdoc",
@@ -2295,12 +2343,12 @@ PYBIND11_MODULE(_xtal, m) {
 
            Parameters
            ----------
-           structure : casm.xtal.Structure
+           structure : ~libcasm.xtal.Structure
                The structure.
 
            Returns
            -------
-           factor_group : List[casm.xtal.SymOp]
+           factor_group : List[:class:`~libcasm.xtal.SymOp`]
                The the set of symmery operations, with translation lying within the primitive unit
                cell, that leave the lattice vectors, atom coordinates, and atom types invariant.
 
@@ -2322,12 +2370,12 @@ PYBIND11_MODULE(_xtal, m) {
 
            Parameters
            ----------
-           structure : casm.xtal.Structure
+           structure : ~libcasm.xtal.Structure
                The structure.
 
            Returns
            -------
-           crystal_point_group : List[casm.xtal.SymOp]
+           crystal_point_group : List[:class:`~libcasm.xtal.SymOp`]
                The crystal point group is the group constructed from the structure factor group
                operations with translation vector set to zero.
 
@@ -2347,12 +2395,12 @@ PYBIND11_MODULE(_xtal, m) {
 
             Parameters
             ----------
-            init_structure : casm.xtal.Structure
+            init_structure : ~libcasm.xtal.Structure
                 The initial structure.
 
             Returns
             -------
-            structure : casm.xtal.Structure
+            structure : ~libcasm.xtal.Structure
                 The structure with all atom and mol site coordinates within the unit cell.
 
             )pbdoc");
@@ -2369,12 +2417,12 @@ PYBIND11_MODULE(_xtal, m) {
       ----------
       transformation_matrix_to_super: array_like, shape=(3,3), dtype=int
           The transformation matrix, T, relating the superstructure lattice vectors, S, to the unit structure lattice vectors, L, according to S = L @ T, where S and L are shape=(3,3)  matrices with lattice vectors as columns.
-      structure: casm.xtal.Structure
+      structure: ~libcasm.xtal.Structure
           The unit structure used to form the superstructure.
 
       Returns
       -------
-      superstructure: casm.xtal.Structure
+      superstructure: ~libcasm.xtal.Structure
           The superstructure.
       )pbdoc");
 
@@ -2386,7 +2434,7 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      point_group : List[casm.xtal.symop]
+      point_group : List[:class:`~libcasm.xtal.Symop`]
           Point group that generates the equivalent property values.
       x : array_like, shape=(m,1)
           The property value, as a vector. For strain, this is the
@@ -2652,13 +2700,78 @@ PYBIND11_MODULE(_xtal, m) {
   py::class_<xtal::UnitCellCoord> pyIntegralSiteCoordinate(
       m, "IntegralSiteCoordinate", R"pbdoc(
       Specify a site using integer sublattice and unit cell indices
-    )pbdoc");
+
+      .. rubric:: Special Methods
+
+      Translate an :class:`~libcasm.xtal.IntegralSiteCoordinate` via operators ``+``, ``-``, ``+=``, ``-=``:
+
+      .. code-block:: Python
+
+          import numpy as np
+          from libcasm.xtal import IntegralSiteCoordinate
+
+          # construct IntegralSiteCoordinate
+          b = 0
+          unitcell = np.array([1, 2, 3])
+          translation = np.array([0, 0, 1])
+          integral_site_coordinate = IntegralSiteCoordinate(b, unitcell)
+
+          # translate via `+=`:
+          integral_site_coordinate += translation
+
+          # translate via `-=`:
+          integral_site_coordinate -= translation
+
+          # copy & translate via `+`:
+          translated_integral_site_coordinate = integral_site_coordinate + translation
+
+          # copy & translate via `-`:
+          translated_integral_site_coordinate = integral_site_coordinate - translation
+
+
+      Sort :class:`~libcasm.xtal.IntegralSiteCoordinate` by lexicographical order of unit cell indices `[i, j, k]` then sublattice index `b` via ``<``, ``<=``, ``>``, ``>=``, and compare via ``==``, ``!=``:
+
+      .. code-block:: Python
+
+          import numpy as np
+          from libcasm.xtal import IntegralSiteCoordinate
+
+          # construct IntegralSiteCoordinate
+          b = 0
+          unitcell = np.array([1, 2, 3])
+          translation = np.array([0, 0, 1])
+          A = IntegralSiteCoordinate(0, np.array([1, 2, 3]))
+          B = IntegralSiteCoordinate(1, np.array([1, 2, 3]))
+
+          assert A < B
+          assert A <= B
+          assert A <= A
+          assert B > A
+          assert B >= A
+          assert B >= B
+          assert A == A
+          assert B == B
+          assert A != B
+
+      )pbdoc");
 
   // IntegralSiteCoordinateRep -- declaration
   py::class_<xtal::UnitCellCoordRep> pyIntegralSiteCoordinateRep(
       m, "IntegralSiteCoordinateRep", R"pbdoc(
-      Symmetry representation for transforming IntegralSiteCoordinate"
-    )pbdoc");
+      Symmetry representation for transforming IntegralSiteCoordinate
+
+      .. rubric:: Special Methods
+
+      Transform an :class:`~libcasm.xtal.IntegralSiteCoordinate` via multiplication operator ``*``:
+
+      .. code-block:: Python
+
+          from libcasm.xtal import IntegralSiteCoordinate, IntegralSiteCoordinateRep
+          rep = IntegralSiteCoordinateRep(...)
+          integral_site_coordinate = IntegralSiteCoordinate(...)
+          transformed_integral_site_coordinate = rep * integral_site_coordinate
+
+      )pbdoc");
 
   // IntegralSiteCoordinate -- definition
   pyIntegralSiteCoordinate
@@ -2810,9 +2923,9 @@ PYBIND11_MODULE(_xtal, m) {
 
       Parameters
       ----------
-      op : casm.xtal.SymOp
+      op : ~libcasm.xtal.SymOp
           The symmetry operation.
-      prim : casm.xtal.Prim
+      prim : ~libcasm.xtal.Prim
           The prim defining IntegralSiteCoordinate that will be transformed.
       )pbdoc")
       .def(
@@ -2822,7 +2935,7 @@ PYBIND11_MODULE(_xtal, m) {
             return copy_apply(rep, integral_site_coordinate);
           },
           py::arg("integral_site_coordinate"),
-          "Transform an :class:`libcasm.xtal.IntegralSiteCoordinate`");
+          "Transform an :class:`~libcasm.xtal.IntegralSiteCoordinate`");
 
   m.def(
       "apply",

--- a/python/src/xtal.cpp
+++ b/python/src/xtal.cpp
@@ -2285,7 +2285,7 @@ PYBIND11_MODULE(_xtal, m) {
            [](xtal::SimpleStructure const &self) {
              return xtal::SimpleStructure(self);
            })
-      .def("__deepcopy__", [](xtal::SimpleStructure const &self) {
+      .def("__deepcopy__", [](xtal::SimpleStructure const &self, py::dict) {
         return xtal::SimpleStructure(self);
       });
 

--- a/python/tests/test_siteindexconverter.py
+++ b/python/tests/test_siteindexconverter.py
@@ -1,0 +1,75 @@
+import libcasm.xtal as xtal
+import numpy as np
+import pytest
+
+
+def test_SiteIndexConverter_1():
+
+    # test constructor
+    f = xtal.SiteIndexConverter(
+        transformation_matrix_to_super=np.array(
+            [
+                [2, 0, 0],
+                [0, 2, 0],
+                [0, 0, 2],
+            ]
+        ),
+        n_sublattice=2,
+    )
+
+    # test total_sites
+    assert f.total_sites() == 16
+
+    # test (b,i,j,k) -> linear_unitcell_index
+    def bijk(b, i, j, k):
+        return xtal.IntegralSiteCoordinate.from_list([b, i, j, k])
+
+    assert f.linear_site_index(bijk(0, 0, 0, 0)) == 0
+    assert f.linear_site_index(bijk(0, 1, 0, 0)) == 1
+    assert f.linear_site_index(bijk(0, 0, 1, 0)) == 2
+    assert f.linear_site_index(bijk(0, 1, 1, 0)) == 3
+    assert f.linear_site_index(bijk(0, 0, 0, 1)) == 4
+    assert f.linear_site_index(bijk(0, 1, 0, 1)) == 5
+    assert f.linear_site_index(bijk(0, 0, 1, 1)) == 6
+    assert f.linear_site_index(bijk(0, 1, 1, 1)) == 7
+    assert f.linear_site_index(bijk(1, 0, 0, 0)) == 8
+    assert f.linear_site_index(bijk(1, 1, 0, 0)) == 9
+    assert f.linear_site_index(bijk(1, 0, 1, 0)) == 10
+    assert f.linear_site_index(bijk(1, 1, 1, 0)) == 11
+    assert f.linear_site_index(bijk(1, 0, 0, 1)) == 12
+    assert f.linear_site_index(bijk(1, 1, 0, 1)) == 13
+    assert f.linear_site_index(bijk(1, 0, 1, 1)) == 14
+    assert f.linear_site_index(bijk(1, 1, 1, 1)) == 15
+
+    assert f.integral_site_coordinate(0) == bijk(0, 0, 0, 0)
+    assert f.integral_site_coordinate(1) == bijk(0, 1, 0, 0)
+    assert f.integral_site_coordinate(2) == bijk(0, 0, 1, 0)
+    assert f.integral_site_coordinate(3) == bijk(0, 1, 1, 0)
+    assert f.integral_site_coordinate(4) == bijk(0, 0, 0, 1)
+    assert f.integral_site_coordinate(5) == bijk(0, 1, 0, 1)
+    assert f.integral_site_coordinate(6) == bijk(0, 0, 1, 1)
+    assert f.integral_site_coordinate(7) == bijk(0, 1, 1, 1)
+    assert f.integral_site_coordinate(8) == bijk(1, 0, 0, 0)
+    assert f.integral_site_coordinate(9) == bijk(1, 1, 0, 0)
+    assert f.integral_site_coordinate(10) == bijk(1, 0, 1, 0)
+    assert f.integral_site_coordinate(11) == bijk(1, 1, 1, 0)
+    assert f.integral_site_coordinate(12) == bijk(1, 0, 0, 1)
+    assert f.integral_site_coordinate(13) == bijk(1, 1, 0, 1)
+    assert f.integral_site_coordinate(14) == bijk(1, 0, 1, 1)
+    assert f.integral_site_coordinate(15) == bijk(1, 1, 1, 1)
+
+    # test explicit bring_within
+    assert f.bring_within(bijk(0, 2, 2, 2)) == bijk(0, 0, 0, 0)
+
+    # test default bring within
+    assert f.linear_site_index(bijk(0, 2, 2, 2)) == 0
+
+    # test never_bring_within
+    with pytest.raises(RuntimeError):
+        f.never_bring_within()
+        assert f.linear_site_index(bijk(0, 2, 2, 2)) == 0
+
+    # test always_bring_within
+    f.never_bring_within()
+    f.always_bring_within()
+    assert f.linear_site_index(bijk(0, 2, 2, 2)) == 0

--- a/python/tests/test_structure.py
+++ b/python/tests/test_structure.py
@@ -157,8 +157,11 @@ def test_structure_to_poscar_str_3(example_structure_2):
 def test_copy_structure(example_structure_1):
     import copy
 
-    structure = copy.copy(example_structure_1)
+    structure1 = copy.copy(example_structure_1)
+    structure2 = copy.deepcopy(example_structure_1)
 
     assert isinstance(example_structure_1, xtal.Structure)
-    assert isinstance(structure, xtal.Structure)
-    assert structure is not example_structure_1
+    assert isinstance(structure1, xtal.Structure)
+    assert structure1 is not example_structure_1
+    assert isinstance(structure2, xtal.Structure)
+    assert structure2 is not example_structure_1

--- a/python/tests/test_unitcellindexconverter.py
+++ b/python/tests/test_unitcellindexconverter.py
@@ -1,0 +1,59 @@
+import libcasm.xtal as xtal
+import numpy as np
+import pytest
+
+
+def test_UnitCellIndexConverter_1():
+
+    # test constructor
+    f = xtal.UnitCellIndexConverter(
+        np.array(
+            [
+                [2, 0, 0],
+                [0, 2, 0],
+                [0, 0, 2],
+            ]
+        )
+    )
+
+    # test total_unitcells
+    assert f.total_unitcells() == 8
+
+    # test make_lattice_points
+    assert len(f.make_lattice_points()) == 8
+
+    # test (i,j,k) -> linear_unitcell_index
+    assert f.linear_unitcell_index(np.array([0, 0, 0])) == 0
+    assert f.linear_unitcell_index(np.array([1, 0, 0])) == 1
+    assert f.linear_unitcell_index(np.array([0, 1, 0])) == 2
+    assert f.linear_unitcell_index(np.array([1, 1, 0])) == 3
+    assert f.linear_unitcell_index(np.array([0, 0, 1])) == 4
+    assert f.linear_unitcell_index(np.array([1, 0, 1])) == 5
+    assert f.linear_unitcell_index(np.array([0, 1, 1])) == 6
+    assert f.linear_unitcell_index(np.array([1, 1, 1])) == 7
+
+    # test linear_unitcell_index -> (i,j,k)
+    assert (f.unitcell(0) == np.array([0, 0, 0])).all()
+    assert (f.unitcell(1) == np.array([1, 0, 0])).all()
+    assert (f.unitcell(2) == np.array([0, 1, 0])).all()
+    assert (f.unitcell(3) == np.array([1, 1, 0])).all()
+    assert (f.unitcell(4) == np.array([0, 0, 1])).all()
+    assert (f.unitcell(5) == np.array([1, 0, 1])).all()
+    assert (f.unitcell(6) == np.array([0, 1, 1])).all()
+    assert (f.unitcell(7) == np.array([1, 1, 1])).all()
+
+    # test explicit bring_within
+    assert (f.bring_within(np.array([2, 2, 2])) == np.array([0, 0, 0])).all()
+
+    # test default bring within
+    assert f.linear_unitcell_index(np.array([2, 2, 2])) == 0
+
+    # test never_bring_within
+    with pytest.raises(RuntimeError):
+        f.never_bring_within()
+        assert f.linear_unitcell_index(np.array([2, 2, 2])) == 0
+
+    # test always_bring_within
+    f.never_bring_within()
+    f.always_bring_within()
+    assert f.linear_unitcell_index(np.array([2, 2, 2])) == 0


### PR DESCRIPTION
This PR:

- adds class libcasm.xtal.UnitCellIndexConverter for conversions between (i,j,k) unit cell indices and linear unit cell index in a supercell
- adds class libcasm.xtal.SiteIndexConverter for conversions between (b,i,j,k) integral site coordinates and linear site index in a supercell
- adds the docs Makefile
- updates docs with examples using special members
- fixes links in docs