### PR TITLE
Structure.from_poscar

### DIFF
--- a/python/tests/test_prim.py
+++ b/python/tests/test_prim.py
@@ -113,6 +113,40 @@ def test_prim_from_poscar_str_with_occ_dof(shared_datadir):
     check_lial_with_occ_dofs(prim, occ_dofs)
 
 
+def test_prim_from_poscar_str_selectivedynamics():
+    poscar_str = """test prim
+    1.0
+    4.0 0.0 0.0
+    0.0 4.0 0.0
+    0.0 0.0 4.0
+    A B
+    1 3
+    Selective dynamics
+    Cartesian
+    0.0 0.0 0.0 T T T
+    0.5 0.5 0.5 T T T
+    0.0 0.0 1.0 F F F
+    0.5 0.5 1.5 T T T
+    """
+    prim = xtal.Prim.from_poscar_str(poscar_str)
+    assert prim.occ_dof() == [["A"], ["B.1"], ["B.2"], ["B.1"]]
+
+    occ_props = prim.occupants()["A"].properties()
+    assert "selectivedynamics" in occ_props
+    assert np.allclose(occ_props["selectivedynamics"], np.array([1.0, 1.0, 1.0]))
+
+    occ_props = prim.occupants()["B.1"].properties()
+    assert "selectivedynamics" in occ_props
+    assert np.allclose(occ_props["selectivedynamics"], np.array([1.0, 1.0, 1.0]))
+
+    occ_props = prim.occupants()["B.2"].properties()
+    assert "selectivedynamics" in occ_props
+    assert np.allclose(occ_props["selectivedynamics"], np.array([0.0, 0.0, 0.0]))
+
+    assert prim.coordinate_frac().shape == (3, 4)
+    assert prim.local_dof() == [[], [], [], []]
+
+
 def test_prim_to_poscar_str(shared_datadir):
     poscar_path = os.path.join(shared_datadir, "lial.vasp")
     prim = xtal.Prim.from_poscar(poscar_path)

--- a/python/tests/test_structure.py
+++ b/python/tests/test_structure.py
@@ -153,6 +153,126 @@ def test_structure_to_poscar_str_3(example_structure_2):
     assert lines[7] == "Direct"
 
 
+def test_structure_from_poscar_str_1():
+    poscar_str = """test structure
+    1.0
+    4.0 0.0 0.0
+    0.0 4.0 0.0
+    0.0 0.0 4.0
+    A B 
+    1 3 
+    Cartesian
+    0.0 0.0 0.0 
+    0.5 0.5 0.5 
+    0.0 0.0 1.0 
+    0.5 0.5 1.5 
+    """
+    structure = xtal.Structure.from_poscar_str(poscar_str)
+
+    assert np.allclose(structure.lattice().column_vector_matrix(), np.eye(3) * 4.0)
+    assert len(structure.mol_type()) == 0
+    assert structure.mol_coordinate_frac().shape == (3, 0)
+    assert len(structure.mol_properties()) == 0
+    assert len(structure.atom_type()) == 4
+    assert structure.atom_coordinate_frac().shape == (3, 4)
+    assert len(structure.atom_properties()) == 0
+
+
+def test_structure_from_poscar_str_with_selectivedynamics_1():
+    poscar_str = """test structure
+    1.0
+    4.0 0.0 0.0
+    0.0 4.0 0.0
+    0.0 0.0 4.0
+    A B
+    1 3
+    Selective dynamics
+    Cartesian
+    0.0 0.0 0.0 T T T
+    0.5 0.5 0.5 T T T
+    0.0 0.0 1.0 F F F
+    0.5 0.5 1.5 T T T
+    """
+    # default, read as atoms
+    structure = xtal.Structure.from_poscar_str(poscar_str)
+
+    assert np.allclose(structure.lattice().column_vector_matrix(), np.eye(3) * 4.0)
+
+    assert len(structure.mol_type()) == 0
+    assert structure.mol_coordinate_frac().shape == (3, 0)
+    assert len(structure.mol_properties()) == 0
+
+    assert len(structure.atom_type()) == 4
+    assert structure.atom_coordinate_frac().shape == (3, 4)
+    assert len(structure.atom_properties()) == 1
+    assert "selectivedynamics" in structure.atom_properties()
+    assert structure.atom_properties()["selectivedynamics"].shape == (3, 4)
+
+
+def test_structure_from_poscar_str_with_selectivedynamics_2():
+    poscar_str = """test structure
+    1.0
+    4.0 0.0 0.0
+    0.0 4.0 0.0
+    0.0 0.0 4.0
+    A B
+    1 3
+    Selective dynamics
+    Cartesian
+    0.0 0.0 0.0 T T T
+    0.5 0.5 0.5 T T T
+    0.0 0.0 1.0 F F F
+    0.5 0.5 1.5 T T T
+    """
+    # default, read as molecules
+    structure = xtal.Structure.from_poscar_str(poscar_str, mode="molecules")
+
+    assert np.allclose(structure.lattice().column_vector_matrix(), np.eye(3) * 4.0)
+
+    assert len(structure.mol_type()) == 4
+    assert structure.mol_coordinate_frac().shape == (3, 4)
+    assert len(structure.mol_properties()) == 1
+    assert "selectivedynamics" in structure.mol_properties()
+    assert structure.mol_properties()["selectivedynamics"].shape == (3, 4)
+
+    assert len(structure.atom_type()) == 0
+    assert structure.atom_coordinate_frac().shape == (3, 0)
+    assert len(structure.atom_properties()) == 0
+
+
+def test_structure_from_poscar_str_with_selectivedynamics_3():
+    poscar_str = """test structure
+    1.0
+    4.0 0.0 0.0
+    0.0 4.0 0.0
+    0.0 0.0 4.0
+    A B
+    1 3
+    Selective dynamics
+    Cartesian
+    0.0 0.0 0.0 T T T
+    0.5 0.5 0.5 T T T
+    0.0 0.0 1.0 F F F
+    0.5 0.5 1.5 T T T
+    """
+    # default, read as atoms & molecules
+    structure = xtal.Structure.from_poscar_str(poscar_str, mode="both")
+
+    assert np.allclose(structure.lattice().column_vector_matrix(), np.eye(3) * 4.0)
+
+    assert len(structure.mol_type()) == 4
+    assert structure.mol_coordinate_frac().shape == (3, 4)
+    assert len(structure.mol_properties()) == 1
+    assert "selectivedynamics" in structure.mol_properties()
+    assert structure.mol_properties()["selectivedynamics"].shape == (3, 4)
+
+    assert len(structure.mol_type()) == 4
+    assert structure.mol_coordinate_frac().shape == (3, 4)
+    assert len(structure.mol_properties()) == 1
+    assert "selectivedynamics" in structure.mol_properties()
+    assert structure.mol_properties()["selectivedynamics"].shape == (3, 4)
+
+
 def test_copy_structure(example_structure_1):
     import copy
 

--- a/src/casm/crystallography/Site.cc
+++ b/src/casm/crystallography/Site.cc
@@ -243,16 +243,16 @@ void Site::read(std::istream &stream, bool SD_is_on) {
 
   char ch;
 
-  Eigen::Vector3i SD_flag;
+  Eigen::Vector3d SD_flag;
 
   Coordinate::read(stream, COORD_MODE::CHECK());
   if (SD_is_on) {
     for (int i = 0; i < 3; i++) {
       stream >> ch;
       if (ch == 'T') {
-        SD_flag[i] = 1;
+        SD_flag[i] = 1.0;
       } else if (ch == 'F') {
-        SD_flag[i] = 0;
+        SD_flag[i] = 0.0;
       }
     }
   }
@@ -270,7 +270,13 @@ void Site::read(std::istream &stream, bool SD_is_on) {
       // Need to change this part for real molecules
       std::string mol_name;
       stream >> mol_name;
-      tocc.push_back(Molecule::make_atom(mol_name));
+      Molecule mol = Molecule::make_atom(mol_name);
+      if (SD_is_on) {
+        AnisoValTraits sd_traits = AnisoValTraits::selective_dynamics();
+        xtal::SpeciesProperty sd_property(sd_traits, SD_flag);
+        mol.set_properties({{sd_property.name(), sd_property}});
+      }
+      tocc.push_back(mol);
     }
     ch = stream.peek();
   }
@@ -335,23 +341,28 @@ void Site::read(std::istream &stream, std::string &elem, bool SD_is_on) {
 
   set_label(-1);
 
-  Eigen::Vector3i SD_flag;
+  Eigen::Vector3d SD_flag;
 
   Coordinate::read(stream, COORD_MODE::CHECK());
   if (SD_is_on) {
     for (int i = 0; i < 3; i++) {
       stream >> ch;
       if (ch == 'T') {
-        SD_flag[i] = 1;
+        SD_flag[i] = 1.0;
       } else if (ch == 'F') {
-        SD_flag[i] = 0;
+        SD_flag[i] = 0.0;
       }
     }
   }
 
   std::vector<Molecule> tocc;
-
-  tocc.push_back(Molecule::make_atom(elem));
+  Molecule mol = Molecule::make_atom(elem);
+  if (SD_is_on) {
+    AnisoValTraits sd_traits = AnisoValTraits::selective_dynamics();
+    xtal::SpeciesProperty sd_property(sd_traits, SD_flag);
+    mol.set_properties({{sd_property.name(), sd_property}});
+  }
+  tocc.push_back(mol);
 
   if (tocc.size()) {
     m_occupant_dof = tocc;


### PR DESCRIPTION
Add `mode` parameter to `Structure.from_poscar` and `Structure.from_poscar_str` to specify whether the POSCAR should be read as atoms, molecules, or both.

Related to https://github.com/prisms-center/CASMcode_mapping/issues/11