### PR TITLE
2.X fix make primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.0a9] - X
+
+### Changed
+
+- Changed make_primitive to act on either Prim or Structure.
+- Added `excluded_species` and `frac` parameters to xtal.Structure.to_dict
+
+### Added
+
+- Add to libcasm.xtal: make_primitive_prim (equivalent to current make_primitive), make_primtive_structure, and make_canonical_structure. 
+- Add options to the BCC and FCC structure factory functions in libcasm.xtal.structures to make the conventional cubic unit cells.
+- Added StructureAtomInfo namedtuple, and methods sort_structure_by_atom_info, sort_structure_by_atom_type, sort_structure_by_atom_coordinate_frac, and sort_structure_by_atom_coordinate_cart
+
+
 ## [2.0a8] - 2023-11-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed make_primitive to act on either Prim or Structure.
+- Changed default of `xtal.Structure.to_dict` to output in fractional coordinates
 - Added `excluded_species` and `frac` parameters to xtal.Structure.to_dict
 
 ### Added
 
 - Add to libcasm.xtal: make_primitive_prim (equivalent to current make_primitive), make_primtive_structure, and make_canonical_structure. 
 - Add options to the BCC and FCC structure factory functions in libcasm.xtal.structures to make the conventional cubic unit cells.
-- Added StructureAtomInfo namedtuple, and methods sort_structure_by_atom_info, sort_structure_by_atom_type, sort_structure_by_atom_coordinate_frac, and sort_structure_by_atom_coordinate_cart
-
+- Add to libcasm.xtal: StructureAtomInfo namedtuple, and methods sort_structure_by_atom_info, sort_structure_by_atom_type, sort_structure_by_atom_coordinate_frac, and sort_structure_by_atom_coordinate_cart
+- Add to libcasm.xtal: substitute_structure_species 
 
 ## [2.0a8] - 2023-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0a9] - X
 
+### Fixed
+
+- Fix CASM::xtal::make_primitive, which was not copying unique_names. This also fixes the output of libcasm.xtal.make_primitive which was losing the occ_dof list as a result.
+
 ### Changed
 
 - Changed make_primitive to act on either Prim or Structure.

--- a/python/libcasm/xtal/__init__.py
+++ b/python/libcasm/xtal/__init__.py
@@ -1,10 +1,15 @@
 """CASM Crystallography"""
 from ._methods import (
+    StructureAtomInfo,
     make_canonical,
     make_crystal_point_group,
     make_factor_group,
     make_primitive,
     make_within,
+    sort_structure_by_atom_coordinate_cart,
+    sort_structure_by_atom_coordinate_frac,
+    sort_structure_by_atom_info,
+    sort_structure_by_atom_type,
 )
 from ._xtal import (
     AtomComponent,

--- a/python/libcasm/xtal/__init__.py
+++ b/python/libcasm/xtal/__init__.py
@@ -3,6 +3,7 @@ from ._methods import (
     make_canonical,
     make_crystal_point_group,
     make_factor_group,
+    make_primitive,
     make_within,
 )
 from ._xtal import (
@@ -29,12 +30,14 @@ from ._xtal import (
     make_atom,
     make_canonical_lattice,
     make_canonical_prim,
+    make_canonical_structure,
     make_equivalent_property_values,
     make_point_group,
     make_prim_crystal_point_group,
     make_prim_factor_group,
     make_prim_within,
-    make_primitive,
+    make_primitive_prim,
+    make_primitive_structure,
     make_structure_crystal_point_group,
     make_structure_factor_group,
     make_structure_within,

--- a/python/libcasm/xtal/__init__.py
+++ b/python/libcasm/xtal/__init__.py
@@ -10,6 +10,7 @@ from ._methods import (
     sort_structure_by_atom_coordinate_frac,
     sort_structure_by_atom_info,
     sort_structure_by_atom_type,
+    substitute_structure_species,
 )
 from ._xtal import (
     AtomComponent,

--- a/python/libcasm/xtal/_methods.py
+++ b/python/libcasm/xtal/_methods.py
@@ -1,5 +1,11 @@
-from typing import Any, Union
+import functools
+import math
+from collections import namedtuple
+from typing import Any, Callable, Union
 
+import numpy as np
+
+import libcasm.casmglobal
 import libcasm.xtal._xtal as _xtal
 
 
@@ -157,3 +163,244 @@ def make_within(
         return _xtal.make_structure_within(obj)
     else:
         raise TypeError(f"TypeError in make_within: received {type(obj).__name__}")
+
+
+@functools.total_ordering
+class ApproximateFloatArray:
+    def __init__(
+        self,
+        arr: np.ndarray,
+        abs_tol: float = libcasm.casmglobal.TOL,
+    ):
+        """Store an array that will be compared lexicographically up to a given
+        absolute tolerance using math.isclose
+
+        Parameters
+        ----------
+        arr: np.ndarray
+            The array to be compared
+
+        abs_tol: float = libcasm.casmglobal.TOL
+            The absolute tolerance
+        """
+        if not isinstance(arr, np.ndarray):
+            raise Exception("Error in ApproximateFloatArray: arr must be a np.ndarray")
+        self.arr = arr
+        self.abs_tol = abs_tol
+
+    def __eq__(self, other):
+        if len(self.arr) != len(other.arr):
+            return False
+        for i in range(len(self.arr)):
+            if not math.isclose(self.arr[i], other.arr[i], abs_tol=self.abs_tol):
+                return False
+        return True
+
+    def __lt__(self, other):
+        if len(self.arr) != len(other.arr):
+            return len(self.arr) < len(other.arr)
+        for i in range(len(self.arr)):
+            if not math.isclose(self.arr[i], other.arr[i], abs_tol=self.abs_tol):
+                return self.arr[i] < other.arr[i]
+        return False
+
+
+StructureAtomInfo = namedtuple(
+    "StructureAtomInfo",
+    ["atom_type", "atom_coordinate_frac", "atom_coordinate_cart", "atom_properties"],
+)
+
+
+def sort_structure_by_atom_info(
+    structure: _xtal.Structure,
+    key: Callable[[StructureAtomInfo], Any],
+    reverse: bool = False,
+) -> _xtal.Structure:
+    """Sort an atomic structure
+
+    Parameters
+    ----------
+    structure: _xtal.Structure
+        The structure to be sorted. Must be an atomic structure only. Raises if
+        ``len(structure.mol_type()) != 0``.
+    key: Callable[[StructureAtomInfo], Any]
+        The function used to return a value which is sorted. This is passed to the
+        `key` parameter of `list.sort()` to sort a `list[StructureAtomInfo]`.
+    reverse: bool = False
+        By default, sort in ascending order. If ``reverse==True``, then sort in
+        descending order.
+
+    Returns
+    -------
+    sorted_structure: _xtal.Structure
+        An equivalent structure with atoms sorted as specified.
+    """
+
+    if len(structure.mol_type()) != 0:
+        raise Exception(
+            "Error: only atomic structures may be sorted using sort_by_atom_info"
+        )
+    atom_type = structure.atom_type()
+    atom_coordinate_frac = structure.atom_coordinate_frac()
+    atom_coordinate_cart = structure.atom_coordinate_cart()
+    atom_properties = structure.atom_properties()
+
+    atoms = []
+    import copy
+
+    for i in range(len(atom_type)):
+        atoms.append(
+            StructureAtomInfo(
+                copy.copy(atom_type[i]),
+                atom_coordinate_frac[:, i].copy(),
+                atom_coordinate_cart[:, i].copy(),
+                {key: atom_properties[key][:, i].copy() for key in atom_properties},
+            )
+        )
+
+    atoms.sort(key=key, reverse=reverse)
+
+    for i, atom in enumerate(atoms):
+        atom_type[i] = atom[0]
+        atom_coordinate_frac[:, i] = atom[1]
+        for key in atom_properties:
+            atom_properties[key][:, i] = atom[2][key]
+
+    sorted_struc = _xtal.Structure(
+        lattice=structure.lattice(),
+        atom_type=atom_type,
+        atom_coordinate_frac=atom_coordinate_frac,
+        atom_properties=atom_properties,
+        global_properties=structure.global_properties(),
+    )
+
+    return sorted_struc
+
+
+def sort_structure_by_atom_type(
+    structure: _xtal.Structure,
+    reverse: bool = False,
+) -> _xtal.Structure:
+    """Sort an atomic structure by atom type
+
+    Parameters
+    ----------
+    structure: _xtal.Structure
+        The structure to be sorted. Must be an atomic structure only. Raises if
+        ``len(structure.mol_type()) != 0``.
+    reverse: bool = False
+        By default, sort in ascending order. If ``reverse==True``, then sort in
+        descending order.
+
+    Returns
+    -------
+    sorted_structure: _xtal.Structure
+        An equivalent structure with atoms sorted by atom type.
+    """
+    return sort_structure_by_atom_info(
+        structure,
+        key=lambda atom_info: atom_info.atom_type,
+        reverse=reverse,
+    )
+
+
+def sort_structure_by_atom_coordinate_frac(
+    structure: _xtal.Structure,
+    order: str = "cba",
+    abs_tol: float = libcasm.casmglobal.TOL,
+    reverse: bool = False,
+) -> _xtal.Structure:
+    """Sort an atomic structure by fractional coordinates
+
+    Parameters
+    ----------
+    structure: _xtal.Structure
+        The structure to be sorted. Must be an atomic structure only. Raises if
+        ``len(structure.mol_type()) != 0``.
+    order: str = "cba"
+        Sort order of fractional coordinate components. Default "cba" sorts by
+        fractional coordinate along the "c" (third) lattice vector first, "b" (second)
+        lattice vector second, and "a" (first) lattice vector third.
+    abs_tol: float = libcasm.casmglobal.TOL
+        Floating point tolerance for coordinate comparisons.
+    reverse: bool = False
+        By default, sort in ascending order. If ``reverse==True``, then sort in
+        descending order.
+
+    Returns
+    -------
+    sorted_structure: _xtal.Structure
+        An equivalent structure with atoms sorted by fractional coordinates.
+    """
+
+    def compare_f(atom_info):
+        values = []
+        for i in range(len(order)):
+            if order[i] == "a":
+                values.append(atom_info.atom_coordinate_frac[0])
+            elif order[i] == "b":
+                values.append(atom_info.atom_coordinate_frac[1])
+            elif order[i] == "c":
+                values.append(atom_info.atom_coordinate_frac[2])
+
+        return ApproximateFloatArray(
+            arr=np.array(values),
+            abs_tol=abs_tol,
+        )
+
+    return sort_structure_by_atom_info(
+        structure,
+        key=compare_f,
+        reverse=reverse,
+    )
+
+
+def sort_structure_by_atom_coordinate_cart(
+    structure: _xtal.Structure,
+    order: str = "zyx",
+    abs_tol: float = libcasm.casmglobal.TOL,
+    reverse: bool = False,
+) -> _xtal.Structure:
+    """Sort an atomic structure by Cartesian coordinates
+
+    Parameters
+    ----------
+    structure: _xtal.Structure
+        The structure to be sorted. Must be an atomic structure only. Raises if
+        ``len(structure.mol_type()) != 0``.
+    order: str = "zyx"
+        Sort order of Cartesian coordinate components. Default "zyx" sorts by
+        "z" Cartesian coordinate first, "y" Cartesian coordinate second, and "x"
+        Cartesian coordinate third.
+    abs_tol: float = libcasm.casmglobal.TOL
+        Floating point tolerance for coordinate comparisons.
+    reverse: bool = False
+        By default, sort in ascending order. If ``reverse==True``, then sort in
+        descending order.
+
+    Returns
+    -------
+    sorted_structure: _xtal.Structure
+        An equivalent structure with atoms sorted by Cartesian coordinates.
+    """
+
+    def compare_f(atom_info):
+        values = []
+        for i in range(len(order)):
+            if order[i] == "x":
+                values.append(atom_info.atom_coordinate_frac[0])
+            elif order[i] == "y":
+                values.append(atom_info.atom_coordinate_frac[1])
+            elif order[i] == "z":
+                values.append(atom_info.atom_coordinate_frac[2])
+
+        return ApproximateFloatArray(
+            arr=np.array(values),
+            abs_tol=abs_tol,
+        )
+
+    return sort_structure_by_atom_info(
+        structure,
+        key=compare_f,
+        reverse=reverse,
+    )

--- a/python/libcasm/xtal/_methods.py
+++ b/python/libcasm/xtal/_methods.py
@@ -3,27 +3,63 @@ from typing import Any, Union
 import libcasm.xtal._xtal as _xtal
 
 
-def make_canonical(
-    obj: Union[_xtal.Lattice, _xtal.Prim],
+def make_primitive(
+    obj: Union[_xtal.Prim, _xtal.Structure],
 ) -> Any:
-    """Make the canonical form of a Lattice or Prim
+    """Make the primitive cell of a Prim or atomic Structure
+
+    Notes
+    -----
+    Currently, for Structure this method only considers atom coordinates and types.
+    Molecular coordinates and types are not considered. Properties are not considered.
+    The default CASM tolerance is used for comparisons. To consider molecules
+    or properties, or to use a different tolerance, use a Prim.
 
     Parameters
     ----------
-    obj: Union[_xtal.Lattice, _xtal.Prim]
-        A Lattice or Prim, which determines whether
-        :func:`~libcasm.xtal.make_canonical_lattice` or
-        :func:`~libcasm.xtal.make_canonical_prim` is called.
+    obj: Union[ _xtal.Prim, _xtal.Structure]
+        A Prim or an atomic Structure, which determines whether
+        :func:`~libcasm.xtal.make_primitive_prim`, or
+        :func:`~libcasm.xtal.make_primitive_structure` is called.
 
     Returns
     -------
-    canonical_obj : Union[_xtal.Lattice, _xtal.Prim]
-        The canonical equivalent Lattice or Prim.
+    canonical_obj : Union[_xtal.Prim, _xtal.Structure]
+        The primitive equivalent Prim or atomic Structure.
+    """
+    if isinstance(obj, _xtal.Prim):
+        return _xtal.make_primitive_prim(obj)
+    elif isinstance(obj, _xtal.Structure):
+        return _xtal.make_primitive_structure(obj)
+    else:
+        raise TypeError(f"TypeError in make_primitive: received {type(obj).__name__}")
+
+
+def make_canonical(
+    obj: Union[_xtal.Lattice, _xtal.Prim, _xtal.Structure],
+) -> Any:
+    """Make an equivalent Lattice, Prim, or Structure with the canonical form
+    of the lattice
+
+    Parameters
+    ----------
+    obj: Union[_xtal.Lattice, _xtal.Prim, _xtal.Structure]
+        A Lattice, Prim, or Structure, which determines whether
+        :func:`~libcasm.xtal.make_canonical_lattice`, or
+        :func:`~libcasm.xtal.make_canonical_prim`,
+        :func:`~libcasm.xtal.make_canonical_structure` is called.
+
+    Returns
+    -------
+    canonical_obj : Union[_xtal.Lattice, _xtal.Prim, _xtal.Structure]
+        The equivalent Lattice, Prim, or Structure with canonical form of the lattice.
     """
     if isinstance(obj, _xtal.Prim):
         return _xtal.make_canonical_prim(obj)
     elif isinstance(obj, _xtal.Lattice):
         return _xtal.make_canonical_lattice(obj)
+    elif isinstance(obj, _xtal.Structure):
+        return _xtal.make_canonical_structure(obj)
     else:
         raise TypeError(f"TypeError in make_canonical: received {type(obj).__name__}")
 

--- a/python/libcasm/xtal/structures.py
+++ b/python/libcasm/xtal/structures.py
@@ -12,8 +12,9 @@ def BCC(
     atom_type: str = "A",
     atom_properties: dict[str, np.ndarray] = {},
     global_properties: dict[str, np.ndarray] = {},
+    conventional=False,
 ) -> xtal.Structure:
-    r"""Construct a primitive BCC structure
+    r"""Construct a BCC structure
 
     Parameters
     ----------
@@ -32,19 +33,36 @@ def BCC(
         Continuous properties associated with entire crystal, if present. Keys must be
         the name of a CASM-supported property type. Values are (m, 1) arrays with
         dimensions matching the standard dimension of the property type.
-
+    conventional : bool = False
+        If True, construct the 2-atom conventional BCC cell instead of the 1-atom
+        primitive cell. Default is False.
     Returns
     -------
     structure : xtal.Structure
         A primitive BCC structure
     """
-    return xtal.Structure(
+    structure = xtal.Structure(
         lattice=xtal_lattices.BCC(r=r, a=a),
         atom_coordinate_frac=np.array([0.0, 0.0, 0.0]),
         atom_type=[atom_type],
         atom_properties=atom_properties,
         global_properties=global_properties,
     )
+    if conventional is True:
+        T_bcc_conventional = np.array(
+            [
+                [0, 1, 1],
+                [1, 0, 1],
+                [1, 1, 0],
+            ],
+            dtype=int,
+        )
+        return xtal.make_superstructure(
+            T_bcc_conventional,
+            structure,
+        )
+    else:
+        return structure
 
 
 def FCC(
@@ -53,8 +71,9 @@ def FCC(
     atom_type: str = "A",
     atom_properties: dict[str, np.ndarray] = {},
     global_properties: dict[str, np.ndarray] = {},
+    conventional: bool = False,
 ) -> xtal.Structure:
-    r"""Construct a primitive FCC structure
+    r"""Construct a FCC structure
 
     Parameters
     ----------
@@ -73,19 +92,37 @@ def FCC(
         Continuous properties associated with entire crystal, if present. Keys must be
         the name of a CASM-supported property type. Values are (m, 1) arrays with
         dimensions matching the standard dimension of the property type.
+    conventional : bool = False
+        If True, construct the 4-atom conventional FCC cell instead of the 1-atom
+        primitive cell. Default is False.
 
     Returns
     -------
     structure : xtal.Structure
         A primitive FCC structure
     """
-    return xtal.Structure(
+    structure = xtal.Structure(
         lattice=xtal_lattices.FCC(r=r, a=a),
         atom_coordinate_frac=np.array([0.0, 0.0, 0.0]),
         atom_type=[atom_type],
         atom_properties=atom_properties,
         global_properties=global_properties,
     )
+    if conventional is True:
+        T_fcc_conventional = np.array(
+            [
+                [-1, 1, 1],
+                [1, -1, 1],
+                [1, 1, -1],
+            ],
+            dtype=int,
+        )
+        return xtal.make_superstructure(
+            T_fcc_conventional,
+            structure,
+        )
+    else:
+        return structure
 
 
 def HCP(

--- a/python/src/xtal.cpp
+++ b/python/src/xtal.cpp
@@ -1831,9 +1831,9 @@ PYBIND11_MODULE(_xtal, m) {
             Parameters
             ----------
             frac : boolean, default=True
-                If True, write basis site positions in fractional coordinates
-                relative to the lattice vectors. If False, write basis site positions
-                in Cartesian coordinates.
+                By default, basis site positions are written in fractional
+                coordinates relative to the lattice vectors. If False, write basis site
+                positions in Cartesian coordinates.
             include_va : boolean, default=False
                 If a basis site only allows vacancies, it is not printed by default.
                 If this is True, basis sites with only vacancies will be included.
@@ -1964,7 +1964,7 @@ PYBIND11_MODULE(_xtal, m) {
             Parameters
             ----------
             frac : boolean, default=True
-                If True, write basis site positions in fractional coordinates
+                By default, basis site positions are written in fractional coordinates
                 relative to the lattice vectors. If False, write basis site positions
                 in Cartesian coordinates.
             include_va : boolean, default=False
@@ -2554,7 +2554,7 @@ PYBIND11_MODULE(_xtal, m) {
           },
           py::arg("excluded_species") =
               std::vector<std::string>({"Va", "VA", "va"}),
-          py::arg("frac") = false, R"pbdoc(
+          py::arg("frac") = true, R"pbdoc(
           Represent the Structure as a Python dict.
 
           Parameters
@@ -2562,10 +2562,9 @@ PYBIND11_MODULE(_xtal, m) {
           excluded_species : list[str] = ["Va", "VA", "va"]
               The names of any molecular or atomic species that should not be included
               in the output.
-          frac : boolean, default=False
-                If True, write coordinates using fractional coordinates
-                relative to the lattice vectors. If False, write coordinates using
-                Cartesian coordinates.
+          frac : boolean, default=True
+              By default, coordinates are written in fractional coordinates relative to
+              the lattice vectors. If False, write coordinates in Cartesian coordinates.
 
           Returns
           -------

--- a/python/src/xtal.cpp
+++ b/python/src/xtal.cpp
@@ -2543,14 +2543,35 @@ PYBIND11_MODULE(_xtal, m) {
           py::arg("data"))
       .def(
           "to_dict",
-          [](xtal::SimpleStructure const &simple) {
+          [](xtal::SimpleStructure const &simple,
+             std::vector<std::string> const &excluded_species, bool frac) {
             jsonParser json;
-            to_json(simple, json);
+            COORD_TYPE mode = frac ? FRAC : CART;
+            std::set<std::string> _excluded_species(excluded_species.begin(),
+                                                    excluded_species.end());
+            to_json(simple, json, _excluded_species, mode);
             return static_cast<nlohmann::json>(json);
           },
-          "Represent the Structure as a Python dict. The `Structure reference "
-          "<https://prisms-center.github.io/CASMcode_docs/formats/casm/"
-          "crystallography/SimpleStructure/>`_ documents the format.")
+          py::arg("excluded_species") =
+              std::vector<std::string>({"Va", "VA", "va"}),
+          py::arg("frac") = false, R"pbdoc(
+          Represent the Structure as a Python dict.
+
+          Parameters
+          ----------
+          excluded_species : list[str] = ["Va", "VA", "va"]
+              The names of any molecular or atomic species that should not be included
+              in the output.
+          frac : boolean, default=False
+                If True, write coordinates using fractional coordinates
+                relative to the lattice vectors. If False, write coordinates using
+                Cartesian coordinates.
+
+          Returns
+          -------
+          data : json
+              The `Structure reference <https://prisms-center.github.io/CASMcode_docs/formats/casm/crystallography/SimpleStructure/>`_ documents the format.
+          )pbdoc")
       .def_static("from_json", &simplestructure_from_json, R"pbdoc(
           Construct a Structure from a JSON-formatted string.
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -407,7 +407,6 @@ def example_structure_1():
         ]
     ).transpose()
     atom_properties = {"disp": atom_disp}
-    print(atom_properties)
 
     # global properties
     np.array(
@@ -421,7 +420,6 @@ def example_structure_1():
     # Hstrain_vector = converter.from_F(F)
     Hstrain_vector = np.array([0.009950330853168087, 0.0, 0.0, 0.0, 0.0, 0.0])
     global_properties = {"Hstrain": Hstrain_vector}
-    print(global_properties)
 
     return xtal.Structure(
         lattice=lattice,

--- a/python/tests/test_prim.py
+++ b/python/tests/test_prim.py
@@ -165,12 +165,14 @@ def test_prim_to_poscar_str(shared_datadir):
 def test_make_primitive_occ(nonprimitive_cubic_occ_prim):
     assert nonprimitive_cubic_occ_prim.coordinate_frac().shape[1] == 2
     prim = xtal.make_primitive(nonprimitive_cubic_occ_prim)
+    assert isinstance(prim, xtal.Prim)
     assert prim.coordinate_frac().shape[1] == 1
 
 
 def test_make_primitive_manydof(test_nonprimitive_manydof_prim):
     assert test_nonprimitive_manydof_prim.coordinate_frac().shape[1] == 2
     prim = xtal.make_primitive(test_nonprimitive_manydof_prim)
+    assert isinstance(prim, xtal.Prim)
     assert prim.coordinate_frac().shape[1] == 1
 
 

--- a/python/tests/test_structure.py
+++ b/python/tests/test_structure.py
@@ -77,7 +77,7 @@ def test_structure_to_dict(example_structure_1):
     assert len(data["global_properties"]) == 1
     assert "Hstrain" in data["global_properties"]
     expected = np.array(
-        [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5], [0.0, 0.0, 1.0], [0.5, 0.5, 1.5]]
+        [[0.0, 0.0, 0.0], [0.5, 0.5, 0.25], [0.0, 0.0, 0.5], [0.5, 0.5, 0.75]]
     )
     print(xtal.pretty_json(data["atom_coords"]))
     assert np.allclose(np.array(data["atom_coords"]), expected)
@@ -87,9 +87,9 @@ def test_structure_to_dict(example_structure_1):
     data = structure.to_dict(excluded_species=["B"])
     assert data["atom_type"] == ["A", "A"]
 
-    data = structure.to_dict(frac=True)
+    data = structure.to_dict(frac=False)
     expected = np.array(
-        [[0.0, 0.0, 0.0], [0.5, 0.5, 0.25], [0.0, 0.0, 0.5], [0.5, 0.5, 0.75]]
+        [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5], [0.0, 0.0, 1.0], [0.5, 0.5, 1.5]]
     )
     print(xtal.pretty_json(data["atom_coords"]))
     assert np.allclose(np.array(data["atom_coords"]), expected)
@@ -695,3 +695,21 @@ def test_structure_sort_structure_by_atom_coordinate_cart():
     ).transpose()
     # print(xtal.pretty_json(sorted_struc.to_dict()))
     assert np.allclose(sorted_struc.atom_coordinate_cart(), expected)
+
+
+def test_substitute_structure_species_1(example_structure_1):
+    assert example_structure_1.atom_type() == ["A", "A", "B", "B"]
+    s2 = xtal.substitute_structure_species(
+        example_structure_1,
+        {"A": "C"},
+    )
+    assert s2.atom_type() == ["C", "C", "B", "B"]
+
+
+def test_substitute_structure_species_2(example_structure_1):
+    assert example_structure_1.atom_type() == ["A", "A", "B", "B"]
+    s2 = xtal.substitute_structure_species(
+        example_structure_1,
+        {"A": "C", "B": "D"},
+    )
+    assert s2.atom_type() == ["C", "C", "D", "D"]

--- a/python/tests/test_structure.py
+++ b/python/tests/test_structure.py
@@ -442,6 +442,57 @@ def test_make_superstructure_2():
     )
 
 
+def test_make_primitive_structure_1():
+    struc = xtal_structures.BCC(r=1)
+    transformation_matrix = np.array([[0, 1, 1], [2, 0, 1], [1, 1, 0]], dtype=int).T
+    assert transformation_matrix.flags.f_contiguous
+    assert transformation_matrix.dtype is np.dtype(np.int64)
+    superstruc = xtal.make_superstructure(transformation_matrix, struc)
+    assert np.allclose(
+        superstruc.lattice().column_vector_matrix(),
+        struc.lattice().column_vector_matrix() @ transformation_matrix,
+    )
+
+    primitive_struc = xtal.make_primitive_structure(superstruc)
+    assert primitive_struc.is_equivalent_to(struc)
+
+
+def test_make_primitive_structure_2():
+    struc = xtal_structures.BCC(r=1)
+    conventional_struc = xtal_structures.BCC(r=1, conventional=True)
+    primitive_struc = xtal.make_primitive_structure(conventional_struc)
+    assert primitive_struc.is_equivalent_to(struc)
+
+
+def test_make_primitive_structure_3():
+    struc = xtal_structures.FCC(r=1)
+    conventional_struc = xtal_structures.FCC(r=1, conventional=True)
+    primitive_struc = xtal.make_primitive_structure(conventional_struc)
+    assert primitive_struc.is_equivalent_to(struc)
+
+
+def test_make_canonical_structure_1():
+    struc = xtal.Structure(
+        lattice=xtal.Lattice(
+            np.array(
+                [
+                    [0.0, 0.0, 1.0],  # z
+                    [1.0, 0.0, 0.0],  # x
+                    [0.0, 1.0, 0.0],  # y
+                ]
+            ).transpose()
+        ),
+        atom_coordinate_frac=np.array(
+            [
+                [0.0, 0.0, 0.0],
+            ]
+        ).transpose(),
+        atom_type=["A"],
+    )
+    canonical_struc = xtal.make_canonical_structure(struc)
+    assert np.allclose(canonical_struc.lattice().column_vector_matrix(), np.eye(3))
+
+
 def test_make_superstructure_and_rotate():
     struc = xtal_structures.BCC(r=1)
     assert len(struc.atom_type()) == 1

--- a/python/tests/test_structures.py
+++ b/python/tests/test_structures.py
@@ -1,14 +1,49 @@
+import numpy as np
+
 import libcasm.xtal.structures as structures
 from libcasm.xtal import Structure
 
 
 def test_construct_all_structures():
+    ## BCC ##
     assert isinstance(structures.BCC(r=1.0), Structure)
     assert isinstance(structures.BCC(a=1.0), Structure)
 
+    structure = structures.BCC(a=1.0, conventional=True)
+    assert isinstance(structure, Structure)
+    assert np.allclose(structure.lattice().column_vector_matrix(), np.eye(3))
+    assert structure.atom_type() == ["A", "A"]
+    assert np.allclose(
+        structure.atom_coordinate_frac(),
+        np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.5, 0.5],
+            ]
+        ).transpose(),
+    )
+
+    ## FCC ##
     assert isinstance(structures.FCC(r=1.0), Structure)
     assert isinstance(structures.FCC(a=1.0), Structure)
 
+    structure = structures.FCC(a=1.0, conventional=True)
+    assert isinstance(structure, Structure)
+    assert np.allclose(structure.lattice().column_vector_matrix(), np.eye(3))
+    assert structure.atom_type() == ["A", "A", "A", "A"]
+    assert np.allclose(
+        structure.atom_coordinate_frac(),
+        np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.5],
+                [0.0, 0.5, 0.5],
+                [0.5, 0.5, 0.0],
+            ]
+        ).transpose(),
+    )
+
+    ## HCP ##
     assert isinstance(structures.HCP(r=1.0), Structure)
     assert isinstance(structures.HCP(r=1.0, c=2.0 * 1.8), Structure)
     assert isinstance(structures.HCP(a=1.0), Structure)

--- a/src/casm/crystallography/BasicStructureTools.cc
+++ b/src/casm/crystallography/BasicStructureTools.cc
@@ -300,14 +300,19 @@ BasicStructure make_primitive(const BasicStructure &non_primitive_struc,
 
   // Fill up the basis
   BasicStructure primitive_struc(primitive_lattice);
+  std::vector<std::vector<std::string>> _unique_names;
+  Index i_site = 0;
   for (Site site_for_prim : non_primitive_struc.basis()) {
     site_for_prim.set_lattice(primitive_struc.lattice(), CART);
     if (find_index(primitive_struc.basis(), site_for_prim, tol) ==
         primitive_struc.basis().size()) {
       site_for_prim.within();
       primitive_struc.set_basis().emplace_back(std::move(site_for_prim));
+      _unique_names.push_back(non_primitive_struc.unique_names()[i_site]);
+      i_site++;
     }
   }
+  primitive_struc.set_unique_names(_unique_names);
 
   // TODO: Do we want this?
   primitive_struc.set_title(non_primitive_struc.title());

--- a/src/casm/crystallography/BasicStructureTools.cc
+++ b/src/casm/crystallography/BasicStructureTools.cc
@@ -308,9 +308,11 @@ BasicStructure make_primitive(const BasicStructure &non_primitive_struc,
         primitive_struc.basis().size()) {
       site_for_prim.within();
       primitive_struc.set_basis().emplace_back(std::move(site_for_prim));
-      _unique_names.push_back(non_primitive_struc.unique_names()[i_site]);
-      i_site++;
+      if (!non_primitive_struc.unique_names().empty()) {
+        _unique_names.push_back(non_primitive_struc.unique_names()[i_site]);
+      }
     }
+    i_site++;
   }
   primitive_struc.set_unique_names(_unique_names);
 


### PR DESCRIPTION
### Fixed

- Fix CASM::xtal::make_primitive, which was not copying unique_names. This also fixes the output of libcasm.xtal.make_primitive which was losing the occ_dof list as a result.

### Changed

- Changed make_primitive to act on either Prim or Structure.
- Changed default of `xtal.Structure.to_dict` to output in fractional coordinates
- Added `excluded_species` and `frac` parameters to xtal.Structure.to_dict

### Added

- Add to libcasm.xtal: make_primitive_prim (equivalent to current make_primitive), make_primtive_structure, and make_canonical_structure. 
- Add options to the BCC and FCC structure factory functions in libcasm.xtal.structures to make the conventional cubic unit cells.
- Add to libcasm.xtal: StructureAtomInfo namedtuple, and methods sort_structure_by_atom_info, sort_structure_by_atom_type, sort_structure_by_atom_coordinate_frac, and sort_structure_by_atom_coordinate_cart
- Add to libcasm.xtal: substitute_structure_species 
